### PR TITLE
Move icon to page action

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,10 +13,12 @@
 		"scripts": ["shRedirect.js"]
 	},
 
-	"browser_action": {
+	"page_action": {
 		"default_icon": {
 			"48": "icons/48-raven.jpg",
 			"96": "icons/96-raven.jpg"
-		}
+        },
+        "show_matches": ["<all_urls>"],
+        "default_title": "Open in Sci-hub"
 	}
-}		
+}

--- a/shRedirect.js
+++ b/shRedirect.js
@@ -42,7 +42,7 @@ function startQuery() {
 
 if(chrome){
 	// Listener
-	chrome.browserAction.onClicked.addListener(function(tab) {
+	chrome.pageAction.onClicked.addListener(function(tab) {
 		// Query current tab
 		chrome.tabs.query(
 			{active: true, currentWindow: true},
@@ -50,5 +50,5 @@ if(chrome){
 		);
 	});
 }else{
-	browser.browserAction.onClicked.addListener( startQuery );
+	browser.pageAction.onClicked.addListener( startQuery );
 }


### PR DESCRIPTION
Hello @RoiArthurB 
I have great use of this extension, so thank you!

Since the button specifically modify a single page at time, I think it should be better to use it as a pageAction instead of a of a browserAction.

Here the relative documentation:
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action and
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions