### PR TITLE
Add context menu for pages and links

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
     "description": "Auto-modify the url to load Sci-Hub page with your article",
 
     "permissions": [
-        "activeTab"
+        "activeTab",
+        "contextMenus"
     ],
     "options_ui": {
       "page": "options.html",

--- a/shRedirect.js
+++ b/shRedirect.js
@@ -2,15 +2,16 @@
  *  GLOBAL VAR
  */
 
-var baseURL = "https://whereisscihub-rf7h2bfl8.now.sh/go/"; //"https://whereisscihub.now.sh/go/";
+// const BASE_URL = "https://whereisscihub.now.sh/go/";
+const BASE_URL = "https://whereisscihub-rf7h2bfl8.now.sh/go/";
 
 // Firefox always has both chrome and browser objects, Chrome has only chrome
 var browser = browser || chrome
 
-function openSciHubTab(tab) {
-    if ( tab.active ){
+function openSciHubTab(tab, url) {
+    if (tab.active) {
         browser.tabs.create({
-            url: baseURL + tab.url,
+            url: BASE_URL + url,
             index: tab.index + 1
         });
     }
@@ -20,5 +21,26 @@ function openSciHubTab(tab) {
  *  EVENT LISTENER
  */
 
-// Listener
-browser.browserAction.onClicked.addListener(function(tab) { openSciHubTab(tab) });
+// browserAction listener
+browser.browserAction.onClicked.addListener(function (tab) { openSciHubTab(tab, tab.url) });
+
+/**
+ * Add context menu to save page.
+ * Docs: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/ContextMenus/create
+ */
+browser.contextMenus.create({
+    id: 'openscihubtab-page',
+    contexts: ['page'],
+    title: 'Open page in Sci-hub',
+    onclick: function (info, tab) { openSciHubTab(tab, info.pageUrl) }
+});
+
+/**
+ * Add context menu to save a selected link.
+ */
+browser.contextMenus.create({
+    id: 'openscihubtab-link',
+    contexts: ['link'],
+    title: 'Open link in Sci-hub',
+    onclick: function (info, tab) { openSciHubTab(tab, info.linkUrl) }
+});


### PR DESCRIPTION
Ehi @RoiArthurB 
Hoping not to bother you too much, this PR leverage the [context menu API](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/ContextMenus/create) in order to provide an even easier way to open the current page in SciHub.

As a bonus, it is now possible to send a link to SciHub without having to open it, by right-clicking on the link and then right-clicking on "Open link in SciHub" in the contextual menu.

Tested on Firefox 72.0.2  and Chrome 79