### PR TITLE
Improve url validation, option dark-mode, chrome fix

### DIFF
--- a/options.html
+++ b/options.html
@@ -6,18 +6,18 @@
     <style>
       body {
         padding: 10px;
-        background-color: white;
-        color: black;
+        background-color: #ffffff;
+        color: #000000;
         height: 100vh;
       }
 
       @media (prefers-color-scheme: dark) {
         body {
           background-color: #202023;
-          color: rgb(249, 249, 250);
+          color: #f9f9fa;
         }
         a {
-          color: rgb(69, 161, 255);
+          color: #45a1ff;
         }
       }
     </style>

--- a/options.html
+++ b/options.html
@@ -3,6 +3,24 @@
 <html>
   <head>
     <meta charset="utf-8"/>
+    <style>
+      body {
+        padding: 10px;
+        background-color: white;
+        color: black;
+        height: 100vh;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          background-color: #202023;
+          color: rgb(249, 249, 250);
+        }
+        a {
+          color: rgb(69, 161, 255);
+        }
+      }
+    </style>
   </head>
 
   <body>

--- a/options.js
+++ b/options.js
@@ -8,6 +8,8 @@
 const SCIHUB_URL = 'ASH-baseUrl';
 const DEFAULT_SCIHUB_URL = 'https://whereisscihub.now.sh/go/';
 
+// Firefox always has both chrome and browser objects, Chrome has only chrome
+var browser = browser || chrome;
 let storage = browser.storage.local;
 let defaultUrlInput = document.getElementById("defaultUrl");
 defaultUrlInput.disabled = true;
@@ -17,7 +19,7 @@ let config = {};
 
 config[SCIHUB_URL] = DEFAULT_SCIHUB_URL;
 
-storage.get(config).then(function(config) {
+storage.get(config, function (config) {
   defaultUrlInput.value = config[SCIHUB_URL];
   last_url = config[SCIHUB_URL];
   defaultUrlInput.disabled = false;

--- a/options.js
+++ b/options.js
@@ -25,16 +25,48 @@ storage.get(config, function (config) {
   defaultUrlInput.disabled = false;
 });
 
+function buildURL(url) {
+  // Check protocol
+  if (!url.startsWith("https://") && !url.startsWith("http://")) {
+    // if absent, assume is http
+    url = "http://" + url
+  }
+  // Check trailing slash
+  if (!url.endsWith("/")) {
+    url = url + "/"
+  }
+  return url
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/API/URL/URL
+function isValidUrl (url) {
+  try {
+    new URL(url)
+  } catch (error) {
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError
+    return false
+  }
+  return true
+}
+
 function registerChanges(e) {
-  if (!e.target.value.match(/^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})).?)(?::\d{2,5})?(?:[/?#]\S*)?\/$/)) {
-    document.getElementById("defaultUrlError").style.display = 'block';
-    document.getElementById("defaultUrlSaved").style.display = 'none';
-  } else {
+  let config = {};
+  if (e.target.value == "") {
     document.getElementById("defaultUrlError").style.display = 'none';
     document.getElementById("defaultUrlSaved").style.display = 'block';
-    let config = {};
-    config[SCIHUB_URL] = e.target.value;
+    config[SCIHUB_URL] = DEFAULT_SCIHUB_URL;
     storage.set(config);
+  } else {
+    let url = buildURL(e.target.value)
+    if (!isValidUrl(url)) {
+      document.getElementById("defaultUrlError").style.display = 'block';
+      document.getElementById("defaultUrlSaved").style.display = 'none';
+    } else {
+      document.getElementById("defaultUrlError").style.display = 'none';
+      document.getElementById("defaultUrlSaved").style.display = 'block';
+      config[SCIHUB_URL] = url;
+      storage.set(config);
+    }
   }
 }
 


### PR DESCRIPTION
Hello @RoiArthurB 
So sorry about the takedown from AMO.

This PR should have been split in three different parts, but I hope you will take a look nonetheless.

1. Fix a breaking bug that made the extension unusable on Chrome
2. Add dark mode detection to the option page, so that it does not blind me during night.

Here's a screenshot: 

![Schermata 2020-02-22 alle 21 22 08](https://user-images.githubusercontent.com/6209647/77921565-3a7fa880-72a0-11ea-8536-19198b4fba3c.png)

It looks quite good on Chrome also. If the browser (or OS) use a light theme, the visual is the original of yours.

3. it leverages the URL parsing abilities of the browser to check the validity of the URL (instead of a Regex) and also accept urls without trailing slash or without protocol.
The in-code comments document this behavior. 